### PR TITLE
Update Year 33 - Data Backup Day (size).txt

### DIFF
--- a/Solutions99+/Year 33 - Data Backup Day (size).txt
+++ b/Solutions99+/Year 33 - Data Backup Day (size).txt
@@ -1,12 +1,12 @@
 -- 7 Billion Humans (2145) --
 -- 33: Data Backup Day --
 
-a:
-mem2 = nearest datacube
-drop
-mem1 = set c
-pickup mem2
-if myitem > mem1:
-	write mem1
+mem1=set w
+mem2=set e
+if mem1>mem2:
+  mem1=set e
+  mem2=set w
 endif
-jump a
+pickup mem2
+write mem1
+drop


### PR DESCRIPTION
The current solution doesn't work. The "nearest" command often takes the value from the pair of the adjacent worker.  Perhaps the behavior of "nearest" has changed? The new solution does not depend on that behavior.