### PR TITLE
Update Year 23 fix: sorting in the other direction

### DIFF
--- a/Solutions99+/Year 23 - Sorting Hall (size).txt
+++ b/Solutions99+/Year 23 - Sorting Hall (size).txt
@@ -3,10 +3,10 @@
 
 pickup s
 a:
-if e < myitem:
+if myitem < e:
 	step e
 endif
-if w > myitem:
+if myitem > w:
 	step w
 endif
 jump a


### PR DESCRIPTION
In fact, the sorting is done in the other direction, the smallest element goes to the left, therefore to the east.

![image](https://user-images.githubusercontent.com/701648/87918318-8dab8000-ca76-11ea-82f9-0f1691479bfd.png)
